### PR TITLE
merge upstream to bustle/mobiledoc-kit v0.12.5 for fixing IME bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
+<a name="0.12.4"></a>
+## <small>0.12.4 (2020-03-13)</small>
+
+* 🐛 Fixed parser plugin handling of top-level comment nodes ([96710ce](https://github.com/bustle/mobiledoc-kit/commit/96710ce))
+* code style ([11d3c5e](https://github.com/bustle/mobiledoc-kit/commit/11d3c5e))
+* code style ([a2cbc85](https://github.com/bustle/mobiledoc-kit/commit/a2cbc85))
+* Fix link tooltips for any font ([c4a0b63](https://github.com/bustle/mobiledoc-kit/commit/c4a0b63))
+* Fixed section parser handling of markup sections inside lists ([b13bebb](https://github.com/bustle/mobiledoc-kit/commit/b13bebb))
+* Fixed spaces added by section parser from newlines in html ([ac5f673](https://github.com/bustle/mobiledoc-kit/commit/ac5f673))
+* Improved section parser handling of blockquote>p ([6229b88](https://github.com/bustle/mobiledoc-kit/commit/6229b88))
+* lint ([e18703b](https://github.com/bustle/mobiledoc-kit/commit/e18703b))
+* Make text selection test asynchronous 🔥 ([192dcb6](https://github.com/bustle/mobiledoc-kit/commit/192dcb6))
+* Restrict dom selector assertion to the qunit fixture element 🦨 ([2e2d60a](https://github.com/bustle/mobiledoc-kit/commit/2e2d60a))
+* Shrink range to only include sections with non-zero selection when toggling sections 🐔 ([071a555](https://github.com/bustle/mobiledoc-kit/commit/071a555))
+* updating model.post.trimTo && editor.post.toggleSection to ignor tail if not selected. Adding tests ([17433a0](https://github.com/bustle/mobiledoc-kit/commit/17433a0))
+* Use wait helper instead of setTimeout in async tests ([b547d4d](https://github.com/bustle/mobiledoc-kit/commit/b547d4d))
+
+
+
 <a name="0.12.3"></a>
 ## <small>0.12.3 (2020-01-28)</small>
 
 * built website from 5fe628e863773b7681954646309d7a6edc5e0523 ([7b87e74](https://github.com/bustle/mobiledoc-kit/commit/7b87e74))
 * In the 0.3.2 renderer, omit empty section attribute arrays 🍭 ([c115337](https://github.com/bustle/mobiledoc-kit/commit/c115337))
+* v0.12.3 ([2cad059](https://github.com/bustle/mobiledoc-kit/commit/2cad059))
 
 
 
@@ -65,6 +85,7 @@
 * Bump yarn deps ([f85346a](https://github.com/bustle/mobiledoc-kit/commit/f85346a))
 * do not group consecutive list sections of different types ([45e4d27](https://github.com/bustle/mobiledoc-kit/commit/45e4d27))
 * Drop Safari from the base testem ([f1486a6](https://github.com/bustle/mobiledoc-kit/commit/f1486a6))
+* Ensure empty (clickable) section when no mobiledoc is given to Editor ([bcf4639](https://github.com/bustle/mobiledoc-kit/commit/bcf4639))
 * Export MOBILEDOC_VERSION & mobiledocRenderers from index ([acbb829](https://github.com/bustle/mobiledoc-kit/commit/acbb829))
 * failing test for #656 ([4bcbec6](https://github.com/bustle/mobiledoc-kit/commit/4bcbec6)), closes [#656](https://github.com/bustle/mobiledoc-kit/issues/656) [#656](https://github.com/bustle/mobiledoc-kit/issues/656)
 * failing test for section parser handling consecutive lists of varying types ([66d2120](https://github.com/bustle/mobiledoc-kit/commit/66d2120))
@@ -581,8 +602,8 @@
 * Update changelog ([9e50f5b](https://github.com/bustle/mobiledoc-kit/commit/9e50f5b))
 * update demo to use ember-mobiledoc-dom-renderer ^0.4.0 ([a1e7cf4](https://github.com/bustle/mobiledoc-kit/commit/a1e7cf4))
 * update readme release instructions ([deb69f3](https://github.com/bustle/mobiledoc-kit/commit/deb69f3))
-* Update README.md ([60b0b4f](https://github.com/bustle/mobiledoc-kit/commit/60b0b4f))
 * Update README.md ([89a17ad](https://github.com/bustle/mobiledoc-kit/commit/89a17ad))
+* Update README.md ([60b0b4f](https://github.com/bustle/mobiledoc-kit/commit/60b0b4f))
 * Use keypress event to enter text ([2701e71](https://github.com/bustle/mobiledoc-kit/commit/2701e71))
 * v0.9.0-beta.1 ([5768110](https://github.com/bustle/mobiledoc-kit/commit/5768110))
 * chore(package): update dependencies ([b9bb08d](https://github.com/bustle/mobiledoc-kit/commit/b9bb08d))
@@ -624,8 +645,8 @@
 * editor#serialize accepts version parameter ([e27bf9b](https://github.com/bustle/mobiledoc-kit/commit/e27bf9b))
 * https URLs for placeholder ([1d2b96d](https://github.com/bustle/mobiledoc-kit/commit/1d2b96d))
 * Migrate cursor API usage over to range ([b56aa16](https://github.com/bustle/mobiledoc-kit/commit/b56aa16))
-* Update changelog ([2667468](https://github.com/bustle/mobiledoc-kit/commit/2667468))
 * Update changelog ([4aeaedb](https://github.com/bustle/mobiledoc-kit/commit/4aeaedb))
+* Update changelog ([2667468](https://github.com/bustle/mobiledoc-kit/commit/2667468))
 * Update README.md ([6e972dd](https://github.com/bustle/mobiledoc-kit/commit/6e972dd))
 * Update README.md ([94bb0a3](https://github.com/bustle/mobiledoc-kit/commit/94bb0a3))
 * Use `node.contains` instead of checking element.parentNode in mutations ([ea9c849](https://github.com/bustle/mobiledoc-kit/commit/ea9c849))
@@ -1405,8 +1426,8 @@
 * mucho trabajo ([2304dc3](https://github.com/bustle/mobiledoc-kit/commit/2304dc3))
 * new transpiler to remove amd ([874115f](https://github.com/bustle/mobiledoc-kit/commit/874115f))
 * Only reference runtime in demo ([1926c95](https://github.com/bustle/mobiledoc-kit/commit/1926c95))
-* overhaul gulp build system. Include compiler in build ([5e39bb2](https://github.com/bustle/mobiledoc-kit/commit/5e39bb2))
 * overhaul gulp build system. Include compiler in build ([3105470](https://github.com/bustle/mobiledoc-kit/commit/3105470))
+* overhaul gulp build system. Include compiler in build ([5e39bb2](https://github.com/bustle/mobiledoc-kit/commit/5e39bb2))
 * parse dom node, not innerHTML ([e77c366](https://github.com/bustle/mobiledoc-kit/commit/e77c366))
 * Pass version number and sections payload on mobiledocs ([148735b](https://github.com/bustle/mobiledoc-kit/commit/148735b))
 * Post nodes no longer store closed and open, but all their markups ([0f69dc1](https://github.com/bustle/mobiledoc-kit/commit/0f69dc1))
@@ -1454,8 +1475,8 @@
 * Update LICENSE year, owners ([442740f](https://github.com/bustle/mobiledoc-kit/commit/442740f))
 * Update MOBILEDOC.md ([e9a5d42](https://github.com/bustle/mobiledoc-kit/commit/e9a5d42))
 * Update README ([9d417f0](https://github.com/bustle/mobiledoc-kit/commit/9d417f0))
-* Update README.md ([504adbe](https://github.com/bustle/mobiledoc-kit/commit/504adbe))
 * Update README.md ([0b9222d](https://github.com/bustle/mobiledoc-kit/commit/0b9222d))
+* Update README.md ([504adbe](https://github.com/bustle/mobiledoc-kit/commit/504adbe))
 * Update renderers ([f775642](https://github.com/bustle/mobiledoc-kit/commit/f775642))
 * update server stuff ([3a01391](https://github.com/bustle/mobiledoc-kit/commit/3a01391))
 * update to work with broccoli multi builder 0.2.2, bring in loader.js to tests ([a0c5c56](https://github.com/bustle/mobiledoc-kit/commit/a0c5c56))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="0.12.5"></a>
+## <small>0.12.5 (2020-10-06)</small>
+
+* Backport fix for IME bug (#745) ([3c20cc9](https://github.com/bustle/mobiledoc-kit/commit/3c20cc9)), closes [#745](https://github.com/bustle/mobiledoc-kit/issues/745)
+* Pin older Node version for 0.12 release branch 💄 (#747) ([958f4cd](https://github.com/bustle/mobiledoc-kit/commit/958f4cd)), closes [#747](https://github.com/bustle/mobiledoc-kit/issues/747)
+
 <a name="0.12.4"></a>
 ## <small>0.12.4 (2020-03-13)</small>
 

--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
     "saucie": "^3.3.2",
     "testem": "^2.17.0"
   },
-  "main": "dist/commonjs/mobiledoc-kit/index.js"
+  "main": "dist/commonjs/mobiledoc-kit/index.js",
+  "volta": {
+    "node": "10.22.1",
+    "yarn": "1.22.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobiledoc-kit",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "A toolkit for building WYSIWYG editors with Mobiledoc",
   "repository": "https://github.com/bustle/mobiledoc-kit",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobiledoc-kit",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "A toolkit for building WYSIWYG editors with Mobiledoc",
   "repository": "https://github.com/bustle/mobiledoc-kit",
   "scripts": {

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -148,6 +148,8 @@ class Editor {
     this._callbacks = new LifecycleCallbacks(values(CALLBACK_QUEUES));
     this._beforeHooks = { toggleMarkup: [] };
 
+    this._isComposingOnBlankLine = false;
+
     DEFAULT_TEXT_INPUT_HANDLERS.forEach(handler => this.onTextInput(handler));
 
     this.hasRendered = false;

--- a/src/js/editor/event-manager.js
+++ b/src/js/editor/event-manager.js
@@ -11,7 +11,15 @@ import SelectionManager from 'mobiledoc-kit/editor/selection-manager';
 import Browser from 'mobiledoc-kit/utils/browser';
 
 const ELEMENT_EVENT_TYPES = [
-  'keydown', 'keyup', 'cut', 'copy', 'paste', 'keypress', 'drop'
+  'keydown',
+  'keyup',
+  'cut',
+  'copy',
+  'paste',
+  'keypress',
+  'drop',
+  'compositionstart',
+  'compositionend',
 ];
 
 export default class EventManager {
@@ -146,6 +154,13 @@ export default class EventManager {
       event.preventDefault();
     }
 
+    // Handle carriage returns
+    if (!key.isEnter() && key.keyCode === 13) {
+      _textInputHandler.handleNewLine();
+      editor.handleNewline(event);
+      return;
+    }
+
     _textInputHandler.handle(key.toString());
   }
 
@@ -166,6 +181,10 @@ export default class EventManager {
     let range = editor.range;
 
     switch(true) {
+      // Ignore keydown events when using an IME
+      case key.isIME(): {
+        break;
+      }
       // FIXME This should be restricted to only card/atom boundaries
       case key.isHorizontalArrowWithoutModifiersOtherThanShift(): {
         let newRange;
@@ -208,6 +227,59 @@ export default class EventManager {
     if (!editor.hasCursor()) { return; }
     let key = Key.fromEvent(event);
     this._updateModifiersFromKey(key, {isDown:false});
+  }
+
+  // The mutation handler interferes with IMEs when composing
+  // on a blank line. These two event handlers are for suppressing
+  // mutation handling in this scenario.
+  compositionstart(event) { // eslint-disable-line
+    let { editor } = this;
+    // Ignore compositionstart if not on a blank line
+    if (editor.range.headMarker) {
+      return;
+    }
+    this._isComposingOnBlankLine = true;
+
+    if (editor.post.isBlank) {
+      editor._insertEmptyMarkupSectionAtCursor();
+    }
+
+    // Stop listening for mutations on Chrome browsers and suppress
+    // mutations by prepending a character for other browsers.
+    // The reason why we treat these separately is because
+    // of the way each browser processes IME inputs.
+    if (Browser.isChrome()) {
+      editor.setPlaceholder('');
+      editor._mutationHandler.stopObserving();
+    } else {
+      this._textInputHandler.handle(' ');
+    }
+  }
+
+  compositionend(event) {
+    let { editor } = this;
+
+    // Ignore compositionend if not composing on blank line
+    if (!this._isComposingOnBlankLine) {
+      return;
+    }
+    this._isComposingOnBlankLine = false;
+
+    // Start listening for mutations on Chrome browsers and
+    // delete the prepended character introduced by compositionstart
+    // for other browsers.
+    if (Browser.isChrome()) {
+      editor.insertText(event.data);
+      editor.setPlaceholder(editor.placeholder);
+      editor._mutationHandler.startObserving();
+    } else {
+      let startOfCompositionLine = editor.range.headSection.toPosition(0);
+      let endOfCompositionLine = editor.range.headSection.toPosition(event.data.length);
+      editor.run(postEditor => {
+        postEditor.deleteAtPosition(startOfCompositionLine, 1, { unit: 'char' });
+        postEditor.setRange(endOfCompositionLine);
+      });
+    }
   }
 
   cut(event) {

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -4,5 +4,8 @@ export default {
   },
   isWin() {
     return (typeof window !== 'undefined') && window.navigator && /Win/.test(window.navigator.platform);
+  },
+  isChrome() {
+    return (typeof window !== 'undefined') && ('chrome' in window);
   }
 };

--- a/tests/acceptance/editor-ime-handler-test.js
+++ b/tests/acceptance/editor-ime-handler-test.js
@@ -1,0 +1,93 @@
+import Keycodes from 'mobiledoc-kit/utils/keycodes';
+import Browser from 'mobiledoc-kit/utils/browser';
+import Helpers from '../test-helpers';
+
+let editor, editorElement;
+
+const { test, module } = Helpers;
+
+module('Acceptance: editor: IME Composition Event Handler', {
+  beforeEach() {
+    editorElement = $('#editor')[0];
+  },
+  afterEach() {
+    if (editor) { editor.destroy(); }
+  }
+});
+
+['Enter', 'Tab', 'Backspace'].forEach((key) => {
+  test(`ignore ${key} keydowns when using an IME`, (assert) => {
+    let { post: expected } = Helpers.postAbstract.buildFromText('你好');
+    editor = Helpers.editor.buildFromText('你好', { element: editorElement });
+
+    Helpers.dom.moveCursorTo(editor, editorElement.firstChild, 1);
+
+    Helpers.dom.triggerKeyEvent(editor, 'keydown', {
+      key,
+      keyCode: Keycodes.IME,
+      charCode: Keycodes[key.toUpperCase()]
+    });
+
+    assert.postIsSimilar(editor.post, expected);
+  });
+});
+
+test('ignore horizontal arrow keydowns when using an IME', (assert) => {
+  editor = Helpers.editor.buildFromText("안녕하세요", { element: editorElement });
+
+  Helpers.dom.moveCursorTo(editor, editorElement.firstChild);
+
+  Helpers.dom.triggerKeyEvent(editor, 'keydown', {
+    key: 'ArrowRight',
+    keyCode: Keycodes.IME,
+    charCode: Keycodes.RIGHT
+  });
+
+  assert.positionIsEqual(editor.range.head, editor.post.headPosition());
+
+  Helpers.dom.moveCursorTo(editor, editorElement.firstChild, 1);
+
+  Helpers.dom.triggerKeyEvent(editor, 'keydown', {
+    key: 'ArrowLeft',
+    keyCode: Keycodes.IME,
+    charCode: Keycodes.LEFT
+  });
+
+  assert.positionIsEqual(editor.range.head, editor.post.tailPosition());
+});
+
+// There doesn't seem to be a way to directly test the usage
+// of an OS-level IME, however this test roughly simulates
+// how the IME inputs text into the DOM.
+test('test handling of IME composition events', (assert) => {
+  let done = assert.async();
+
+  editor = Helpers.editor.buildFromText("", { element: editorElement });
+
+  Helpers.dom.moveCursorTo(editor, editorElement);
+
+  editor.element.dispatchEvent(
+    new CompositionEvent('compositionstart', { 'data': 'n' })
+  );
+
+  Helpers.wait(() => {
+    if(Browser.isChrome()) {
+      editorElement.firstChild.innerHTML = "こんにちは";
+    } else {
+      editorElement.firstChild.innerHTML += "こんにちは";
+    }
+
+    Helpers.wait(() => {
+      editor.element.dispatchEvent(
+        new CompositionEvent('compositionend', { 'data': 'こんにちは' })
+      );
+
+      Helpers.wait(() => {
+        assert.positionIsEqual(editor.range.head, editor.post.tailPosition());
+        assert.hasElement('#editor p:contains(こんにちは)');
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
HI.

This PR is port from bustle/mobiledoc-kit v0.12.5 and solves IME bugs as reported bustle#548, TryGhost/Ghost#11460.

Originally, this solution is based on bustle/mobile-doc-kit v0.13.x, made by @ruiokada in bustle#738.

Ghost still uses mobiledoc-kit v0.12.x. the bugfix is backported in bustle#746 and the newer 0.12.5 was released https://github.com/bustle/mobiledoc-kit/releases/tag/v0.12.5.

Could you merge it and release like mobiledoc-kit 0.12.5-ghost.1 and the newer ghost-admin which uses 0.12.5-ghost.1?
